### PR TITLE
Bump detekt version to 1.14.0

### DIFF
--- a/buildSrc/src/main/kotlin/BuildPlugins.kt
+++ b/buildSrc/src/main/kotlin/BuildPlugins.kt
@@ -18,7 +18,7 @@ object BuildPlugins {
 
     object Versions {
         const val ktlintPlugin = "9.4.0"
-        const val detektPlugin = "1.13.1"
+        const val detektPlugin = "1.14.0"
         const val jacocoPlugin = "0.16.0"
     }
 }


### PR DESCRIPTION
## :speak_no_evil: What
Bump detekt version to 1.14.0

## :hear_no_evil: How
Update detekt version in BuildPlugins.

## :see_no_evil: Screenshot
N/A
